### PR TITLE
予定の追加確認メッセージの修正

### DIFF
--- a/generateFlexMessage.js
+++ b/generateFlexMessage.js
@@ -19,7 +19,12 @@ function generateFlexMessageToConfirmEvent(event) {
         calender_of_flex_message,
         separator_component,
         event_time_of_flex_message,
-        separator_component,
+      ]
+    },
+    footer:{
+      type: "box",
+      layout: "vertical",
+      contents:[
         confirm_button_of_flex_messsage
       ]
     }
@@ -197,6 +202,6 @@ function generateFlexMessageWithConfirmButton(event){
     },
     color: "#FF0000",
     style: "primary",
-  }
+  };
   return confirm_button_component;
 }

--- a/generateFlexMessage.js
+++ b/generateFlexMessage.js
@@ -129,19 +129,57 @@ function generateFlexMessageWithCalender(event){
 
 // イベントの開始時間，終了時間を表記する
 function generateFlexMessageWithEventTime(event){
-  const event_time_formatted = formatEvent(event);
-  var event_time_component = {
+  const start_time_formated = adjustDate(event.getStartTime())
+  const end_time_formated = adjustDate(event.getEndTime())
+  
+  var event_time_component = 
+  {
     type: "box",
-    layout: "horizontal",
-    contents: [
+    layout: "vertical",
+    margin: "lg",
+    spacing: "sm",
+    contents:[
       {
-        type: "text",
-        text: event_time_formatted,
-        size: "md",
-        align: "center",
+        type: "box",
+        layout: "baseline",
+        spacing: "md",
+        contents: [
+          {
+            type: "text",
+            text: "開始",
+            size: "md",
+            flex: 1
+          },
+          {
+            type: "text",
+            text: start_time_formated,
+            size: "md",
+            wrap: true,
+            flex: 5
+          }
+        ]
+      },
+      {
+        type: "box",
+        layout: "baseline",
+        spacing: "md",
+        contents:[
+          {
+            type: "text",
+            text: "終了",
+            size: "md",
+            flex: 1
+          },
+          {
+            type: "text",
+            text: end_time_formated,
+            size: "md",
+            wrap: true,
+            flex: 5
+          }
+        ]
       }
     ],
-    margin: "sm"
   };
   return event_time_component;
 }

--- a/main.js
+++ b/main.js
@@ -420,3 +420,10 @@ function notifyEventsInWeek(){
 
   UrlFetchApp.fetch(url, params);
 }
+
+function debugBySpreadSheet(url,debug_str){
+  const spreadsheet = SpreadsheetApp.openByUrl(url);
+  const sheet = spreadsheet.getActiveSheet();
+  var cell = sheet.getRange("A1");
+  cell.setValue(debug_str);
+}

--- a/main.js
+++ b/main.js
@@ -20,9 +20,9 @@ var today = new Date();
 var tommorow = new Date(today);
 tommorow.setDate(tommorow.getDate()+1);
 
-// 時間を見やすく調整(ex. 00時00分)
+// 日程を見やすく調整(ex. 00月00日 00時00分)
 function adjustDate(date){
-  return date.getHours().toString().padStart(2,"0")+"時"+date.getMinutes().toString().padStart(2,"0")+"分";
+  return (date.getMonth()+1).toString() + "月" + data.getDate() + "日 "+date.getHours().toString().padStart(2,"0")+"時"+date.getMinutes().toString().padStart(2,"0")+"分";
 }
 // イベントの出力を見やすく調整
 function formatEvent(event){

--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ tommorow.setDate(tommorow.getDate()+1);
 
 // 日程を見やすく調整(ex. 00月00日 00時00分)
 function adjustDate(date){
-  return (date.getMonth()+1).toString() + "月" + data.getDate() + "日 "+date.getHours().toString().padStart(2,"0")+"時"+date.getMinutes().toString().padStart(2,"0")+"分";
+  return (date.getMonth()+1).toString() + "月" + date.getDate() + "日 "+date.getHours().toString().padStart(2,"0")+"時"+date.getMinutes().toString().padStart(2,"0")+"分";
 }
 // イベントの出力を見やすく調整
 function formatEvent(event){


### PR DESCRIPTION
### PRで実現したいこと
予定の追加確認メッセージで開始と終了日程が見にくかったため，「開始」と「終了」の項目を設けてそれぞれ表示するようにした．
また，ボタンをfooterに設定して少し整えた．